### PR TITLE
refactor: migrate navigation to go_router for web support

### DIFF
--- a/lib/firebase/firestore/esport/group/gn_esport_group.dart
+++ b/lib/firebase/firestore/esport/group/gn_esport_group.dart
@@ -89,6 +89,23 @@ class GNEsportGroup extends Equatable {
     };
   }
 
+  // Creates a minimal placeholder used when only the group ID is known
+  // (e.g. direct URL access). Real data is fetched via GetGroupDetail.
+  factory GNEsportGroup.placeholder(String id) {
+    final now = DateTime.fromMillisecondsSinceEpoch(0);
+    return GNEsportGroup(
+      id: id,
+      esportId: '',
+      groupName: '',
+      ownerId: '',
+      members: const [],
+      description: '',
+      createdAt: now,
+      updatedAt: now,
+      status: 'active',
+    );
+  }
+
   // key-value pairs of the object
   static const String esportIdKey = 'esportId';
   static const String groupNameKey = 'groupName';

--- a/lib/presentation/esport/groups/group_detail/group_detail_page.dart
+++ b/lib/presentation/esport/groups/group_detail/group_detail_page.dart
@@ -7,15 +7,17 @@ import 'bloc/group_detail_bloc.dart';
 import 'group_detail_view.dart';
 
 class GroupDetailPage extends StatelessWidget {
-  final GNEsportGroup group;
-  const GroupDetailPage({super.key, required this.group});
+  final String groupId;
+  final GNEsportGroup? initialGroup;
+  const GroupDetailPage({super.key, required this.groupId, this.initialGroup});
 
   @override
   Widget build(BuildContext context) {
+    final group = initialGroup ?? GNEsportGroup.placeholder(groupId);
     return BlocProvider(
       create: (_) => GroupDetailBloc(getIt(), group)
-        ..add(GetGroupDetail(group.id))
-        ..add(GetMembers(group.id)),
+        ..add(GetGroupDetail(groupId))
+        ..add(GetMembers(groupId)),
       child: const GroupDetailView(),
     );
   }

--- a/lib/presentation/esport/groups/groups_view.dart
+++ b/lib/presentation/esport/groups/groups_view.dart
@@ -100,7 +100,7 @@ class GroupsView extends StatelessWidget {
                                 group: state.userGroups[index],
                                 onTap: () async {
                                   await context.push(
-                                    Routing.groupDetail,
+                                    Routing.groupDetailPath(state.userGroups[index].id),
                                     extra: state.userGroups[index],
                                   );
                                   if (context.mounted) {
@@ -126,7 +126,7 @@ class GroupsView extends StatelessWidget {
                                 group: state.otherGroups[index],
                                 onTap: () async {
                                   await context.push(
-                                    Routing.groupDetail,
+                                    Routing.groupDetailPath(state.otherGroups[index].id),
                                     extra: state.otherGroups[index],
                                   );
                                   if (context.mounted) {

--- a/lib/presentation/esport/tournament/tournament_view.dart
+++ b/lib/presentation/esport/tournament/tournament_view.dart
@@ -187,10 +187,7 @@ class _MyLeaguesTab extends StatelessWidget {
     return TournamentItem(
       league: league,
       onTap: () async {
-        await context.push(
-          Routing.tournamentDetail,
-          extra: league.id,
-        );
+        await context.push(Routing.tournamentDetailPath(league.id));
         // Returning from the detail page may have changed the league
         // (status, name, participants) — refresh the "my" list silently.
         if (context.mounted) {
@@ -286,8 +283,7 @@ class _OtherLeaguesTabState extends State<_OtherLeaguesTab> {
                 return TournamentItem(
                   league: state.otherLeagues[index],
                   onTap: () => context.push(
-                    Routing.tournamentDetail,
-                    extra: state.otherLeagues[index].id,
+                    Routing.tournamentDetailPath(state.otherLeagues[index].id),
                   ),
                 );
               },

--- a/lib/presentation/notification/notification_item.dart
+++ b/lib/presentation/notification/notification_item.dart
@@ -45,8 +45,7 @@ class NotificationItem extends StatelessWidget {
                   GNNotificationType.esportsLeague &&
               notification.relatedId != null) {
             context.push(
-              Routing.tournamentDetail,
-              extra: notification.relatedId,
+              Routing.tournamentDetailPath(notification.relatedId!),
             );
           }
         },

--- a/lib/routing.dart
+++ b/lib/routing.dart
@@ -27,9 +27,12 @@ class Routing {
   // community
   static const String createTeam = '/create-team';
 
-  // esport
-  static const String groupDetail = '/group-detail';
-  static const String tournamentDetail = '/tournament-detail';
+  // esport — base paths, use helper methods for navigation
+  static const String groupDetail = '/group';
+  static const String tournamentDetail = '/tournament';
+
+  static String groupDetailPath(String groupId) => '/group/$groupId';
+  static String tournamentDetailPath(String leagueId) => '/tournament/$leagueId';
 
   // profile
   static const String updateProfile = '/update-profile';
@@ -112,19 +115,24 @@ final GoRouter appRouter = GoRouter(
           ),
         ),
         GoRoute(
-          path: Routing.groupDetail,
+          path: '/group/:groupId',
           pageBuilder: (context, state) => _slide(
             context: context,
             state: state,
-            child: GroupDetailPage(group: state.extra! as GNEsportGroup),
+            child: GroupDetailPage(
+              groupId: state.pathParameters['groupId']!,
+              initialGroup: state.extra as GNEsportGroup?,
+            ),
           ),
         ),
         GoRoute(
-          path: Routing.tournamentDetail,
+          path: '/tournament/:leagueId',
           pageBuilder: (context, state) => _slide(
             context: context,
             state: state,
-            child: TournamentDetailPage(leagueId: state.extra! as String),
+            child: TournamentDetailPage(
+              leagueId: state.pathParameters['leagueId']!,
+            ),
           ),
         ),
         GoRoute(


### PR DESCRIPTION
## Summary

- Thay thế Flutter standard Navigator bằng **go_router** để hỗ trợ đầy đủ web URL routing
- Bật **`usePathUrlStrategy()`** để loại bỏ `/#/` khỏi tất cả URL trên web
- Encode ID vào URL path để **refresh trang hoạt động đúng** (không mất data)

## Chi tiết thay đổi

### Core routing
- `pubspec.yaml`: thêm `go_router ^14.0.0`
- `main.dart`: gọi `usePathUrlStrategy()` trước `runApp`
- `routing.dart`: rewrite với `GoRouter` + `ShellRoute` + `CustomTransitionPage` (giữ nguyên slide transition 200ms)
- `app.dart`: `MaterialApp` → `MaterialApp.router`, `WebShell` chuyển vào `ShellRoute`

### URL path parameters
| Route cũ | Route mới | Refresh |
|---|---|---|
| `/group-detail` + extra | `/group/:groupId` | ✅ |
| `/tournament-detail` + extra | `/tournament/:leagueId` | ✅ |

- `GNEsportGroup.placeholder(id)`: factory tạo minimal group khi chỉ có ID từ URL — bloc vẫn fetch đầy đủ data qua `GetGroupDetail`
- Thêm `Routing.groupDetailPath(id)` và `tournamentDetailPath(id)` helper methods

### Page refactoring
- `TournamentDetailPage`, `GroupDetailPage`, `UpdateProfilePage`: thêm typed constructor params, xóa `ModalRoute.of()`
- `SettingPage`: nhận `ProfileBloc` qua constructor (go_router routes không share widget-tree scope)

### Call sites (8 files)
- `Navigator.pushNamed` → `context.push`
- `pushReplacementNamed` → `context.go`
- `arguments:` → path params hoặc `extra:`
- `Navigator.pop()` giữ nguyên (go_router tương thích)

## Test plan
- [ ] Chạy web: URL phải là `https://domain.com/tournament/abc123` (không có `/#/`)
- [ ] Refresh `/group/:id` và `/tournament/:id` — trang load đúng data
- [ ] Browser back button điều hướng đúng
- [ ] Mobile: navigate bình thường (`usePathUrlStrategy` là no-op trên mobile)
- [ ] `flutter test` pass

https://claude.ai/code/session_012zCVgoj9iFMBKnvJ5qk6UD

---
_Generated by [Claude Code](https://claude.ai/code/session_012zCVgoj9iFMBKnvJ5qk6UD)_