### PR TITLE
fix(web): URL updates correctly when navigating to detail pages

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import 'core/theme/app_theme.dart';
 import 'core/theme/theme_provider.dart';
+import 'presentation/web_shell/web_shell.dart';
 import 'routing.dart';
 
 class App extends StatelessWidget {
@@ -18,6 +19,8 @@ class App extends StatelessWidget {
           theme: AppTheme.light,
           darkTheme: AppTheme.dark,
           themeMode: themeNotifier.themeMode,
+          builder: (context, child) =>
+              WebShell(child: child ?? const SizedBox.shrink()),
         );
       },
     );

--- a/lib/routing.dart
+++ b/lib/routing.dart
@@ -15,7 +15,6 @@ import 'presentation/profile/change_password/change_password_page.dart';
 import 'presentation/profile/feedback/feedback_view.dart';
 import 'presentation/profile/setting/setting_page.dart';
 import 'presentation/profile/update/update_profile_page.dart';
-import 'presentation/web_shell/web_shell.dart';
 
 class Routing {
   static const String app = '/';
@@ -77,105 +76,100 @@ final GoRouter appRouter = GoRouter(
     return null;
   },
   routes: [
-    ShellRoute(
-      builder: (context, state, child) => WebShell(child: child),
+    GoRoute(
+      path: Routing.app,
+      pageBuilder: (context, state) => _slide(
+        context: context,
+        state: state,
+        child: const AppView(),
+      ),
+    ),
+    GoRoute(
+      path: Routing.offline,
+      pageBuilder: (context, state) => _slide(
+        context: context,
+        state: state,
+        child: const OfflineView(),
+      ),
       routes: [
         GoRoute(
-          path: Routing.app,
-          pageBuilder: (context, state) => _slide(
-            context: context,
-            state: state,
-            child: const AppView(),
-          ),
-        ),
-        GoRoute(
-          path: Routing.offline,
+          path: 'league',
           pageBuilder: (context, state) => _slide(
             context: context,
             state: state,
             child: const OfflineView(),
           ),
-          routes: [
-            GoRoute(
-              path: 'league',
-              pageBuilder: (context, state) => _slide(
-                context: context,
-                state: state,
-                child: const OfflineView(),
-              ),
-            ),
-          ],
-        ),
-        GoRoute(
-          path: Routing.verify,
-          pageBuilder: (context, state) => _slide(
-            context: context,
-            state: state,
-            child: const VerifyPage(),
-          ),
-        ),
-        GoRoute(
-          path: '/group/:groupId',
-          pageBuilder: (context, state) => _slide(
-            context: context,
-            state: state,
-            child: GroupDetailPage(
-              groupId: state.pathParameters['groupId']!,
-              initialGroup: state.extra as GNEsportGroup?,
-            ),
-          ),
-        ),
-        GoRoute(
-          path: '/tournament/:leagueId',
-          pageBuilder: (context, state) => _slide(
-            context: context,
-            state: state,
-            child: TournamentDetailPage(
-              leagueId: state.pathParameters['leagueId']!,
-            ),
-          ),
-        ),
-        GoRoute(
-          path: Routing.updateProfile,
-          pageBuilder: (context, state) => _slide(
-            context: context,
-            state: state,
-            child: UpdateProfilePage(user: state.extra as GNUser?),
-          ),
-        ),
-        GoRoute(
-          path: Routing.setting,
-          pageBuilder: (context, state) => _slide(
-            context: context,
-            state: state,
-            child: SettingPage(profileBloc: state.extra! as ProfileBloc),
-          ),
-        ),
-        GoRoute(
-          path: Routing.changePassword,
-          pageBuilder: (context, state) => _slide(
-            context: context,
-            state: state,
-            child: const ChangePasswordPage(),
-          ),
-        ),
-        GoRoute(
-          path: Routing.notification,
-          pageBuilder: (context, state) => _slide(
-            context: context,
-            state: state,
-            child: const NotificationPage(),
-          ),
-        ),
-        GoRoute(
-          path: Routing.feedback,
-          pageBuilder: (context, state) => _slide(
-            context: context,
-            state: state,
-            child: const FeedbackView(),
-          ),
         ),
       ],
+    ),
+    GoRoute(
+      path: Routing.verify,
+      pageBuilder: (context, state) => _slide(
+        context: context,
+        state: state,
+        child: const VerifyPage(),
+      ),
+    ),
+    GoRoute(
+      path: '/group/:groupId',
+      pageBuilder: (context, state) => _slide(
+        context: context,
+        state: state,
+        child: GroupDetailPage(
+          groupId: state.pathParameters['groupId']!,
+          initialGroup: state.extra as GNEsportGroup?,
+        ),
+      ),
+    ),
+    GoRoute(
+      path: '/tournament/:leagueId',
+      pageBuilder: (context, state) => _slide(
+        context: context,
+        state: state,
+        child: TournamentDetailPage(
+          leagueId: state.pathParameters['leagueId']!,
+        ),
+      ),
+    ),
+    GoRoute(
+      path: Routing.updateProfile,
+      pageBuilder: (context, state) => _slide(
+        context: context,
+        state: state,
+        child: UpdateProfilePage(user: state.extra as GNUser?),
+      ),
+    ),
+    GoRoute(
+      path: Routing.setting,
+      pageBuilder: (context, state) => _slide(
+        context: context,
+        state: state,
+        child: SettingPage(profileBloc: state.extra! as ProfileBloc),
+      ),
+    ),
+    GoRoute(
+      path: Routing.changePassword,
+      pageBuilder: (context, state) => _slide(
+        context: context,
+        state: state,
+        child: const ChangePasswordPage(),
+      ),
+    ),
+    GoRoute(
+      path: Routing.notification,
+      pageBuilder: (context, state) => _slide(
+        context: context,
+        state: state,
+        child: const NotificationPage(),
+      ),
+    ),
+    GoRoute(
+      path: Routing.feedback,
+      pageBuilder: (context, state) => _slide(
+        context: context,
+        state: state,
+        child: const FeedbackView(),
+      ),
     ),
   ],
 );


### PR DESCRIPTION
## Summary

- Sửa lỗi URL không thay đổi khi mở tournament detail / group detail trên web
- Bỏ `ShellRoute`, flatten tất cả routes lên top-level `GoRoute`
- Đưa `WebShell` về `MaterialApp.router.builder`

## Root cause

`ShellRoute` tạo một **nested Navigator** riêng. Khi `context.push('/tournament/123')` được gọi từ bên trong shell, go_router đẩy route lên nested Navigator đó thay vì root Navigator — screen mở được nhưng URL trên browser không cập nhật.

## Fix

Bỏ `ShellRoute`, flat tất cả routes lên top-level `GoRoute` → mọi `context.push()` đều đi qua root Navigator của go_router → URL luôn cập nhật đúng.

`WebShell` được đưa về `MaterialApp.router.builder` (giống cách hoạt động ban đầu trước khi dùng go_router).

## Test plan
- [ ] Mở tournament detail → URL đổi thành `/tournament/:id`
- [ ] Mở group detail → URL đổi thành `/group/:id`
- [ ] Refresh `/tournament/:id` và `/group/:id` → trang load đúng data
- [ ] Browser back button hoạt động đúng

https://claude.ai/code/session_012zCVgoj9iFMBKnvJ5qk6UD

---
_Generated by [Claude Code](https://claude.ai/code/session_012zCVgoj9iFMBKnvJ5qk6UD)_